### PR TITLE
Allow StatsBase 0.33

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 CovarianceEstimation = "0.2.3"
 PosDefManifold = "0.4.6"
-StatsBase = "0.32.0"
+StatsBase = "0.32.0, 0.33"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
StatsBase made a breaking 0.33 release; the only breaking change seems to be https://github.com/JuliaStats/StatsBase.jl/pull/567, and I didn't see any use of `fptype` in this package, but hopefully the tests will say if it really is compatible or not.

By the way, https://github.com/Marco-Congedo/Diagonalizations.jl/pull/55 would help automate this :).